### PR TITLE
Fix osscilation in Scroll

### DIFF
--- a/AutoScroller/AutoScroller.cpp
+++ b/AutoScroller/AutoScroller.cpp
@@ -18,13 +18,12 @@ AutoScroller::AutoScroller()
 
 void AutoScroller::Scroll(const Point& p)
 {
-	if (!HasPane()) {
-		return;
+	if (HasPane()) {
+		Rect _r = pane->GetRect();
+		Rect r(-p, _r.GetSize());
+		pane->SetRect(r);
+		WhenScrolled();
 	}
-	Rect _r = pane->GetRect();
-	Rect r(-p, _r.GetSize());
-	pane->SetRect(r);
-	WhenScrolled();
 }
 
 void AutoScroller::OnScroll()
@@ -34,13 +33,8 @@ void AutoScroller::OnScroll()
 
 void AutoScroller::Layout()
 {
-	Size psz = GetSize();
+	Size psz = scroll.GetReducedViewSize();
 	scroll.SetPage(psz);
-	if (!HasPane()) {
-		return;
-	}
-	Size tsz = pane->GetSize();
-	scroll.SetTotal(tsz);
 }
 
 void AutoScroller::MouseWheel(Point, int zdelta, dword)

--- a/AutoScroller/AutoScroller.h
+++ b/AutoScroller/AutoScroller.h
@@ -19,10 +19,12 @@ namespace Upp
 		void DisableScroll()         { EnableScroll(false); }
 		bool IsScrollEnabled() const { return scroll.x.IsEnabled() || scroll.y.IsEnabled(); }
 	
-		void AddPane(Ctrl& c)        { ClearPane(); pane = &c; Add(c); }
+		void AddPane(Ctrl& c, Size sz) { ClearPane(); pane = &c; Add(c); scroll.SetTotal(sz); }
+		void AddPane(Ctrl& c)          { AddPane(c, c.GetSize()); }
+		
 		Ctrl* GetPane() const        { return pane; }
-		bool HasPane() const         { return (~pane != nullptr); }
-		void ClearPane()             { if(! ~pane) return; pane->Remove(); pane = nullptr; }
+		bool HasPane() const         { return pane; }
+		void ClearPane()             { if(pane) { pane->Remove(); pane = nullptr; } }
 	
 		void Scroll(const Point& p);
 		void OnScroll();


### PR DESCRIPTION
Rationale: GetSize is not a fixed value - it depends on actual state of frame. As we are using AutoHide scrollbar here, GetSize can depend on whether ScrollBar is visible or not, which can lead to infinite recursive loop.

The correct approach is to specify the size at AddPane and use GetLayoutSize there (maybe fix example to do this too); with fallback overload that just snapshots GetSize at the moment of AddPane - that is less safe, but should work in most situations.